### PR TITLE
Adding a parser for nfo files

### DIFF
--- a/nfo/nodes/__init__.py
+++ b/nfo/nodes/__init__.py
@@ -205,7 +205,7 @@ class Float(Singleton, ValidRangeMixin):
 
 class Date(Singleton):
 
-	default = datetime(year=1969, month=12, day=31, hour=0, minute=0)
+	default = None # was : datetime(year=1969, month=12, day=31, hour=0, minute=0)
 
 	def __init__(self, element_name, format_string='%Y-%m-%d', default=None, required=False):
 		self.__value = None

--- a/nfo/nodes/tvshows.py
+++ b/nfo/nodes/tvshows.py
@@ -7,68 +7,68 @@ from nfo import _oodict
 
 
 _string_elements = (
-	('title', None),
-	('showtitle', None),
-	('uniqueid', None),
-	('outline', None),
-	('plot', None),
-	('tagline', None),
-	('mpaa', None),
-	('playcount', None),
-	('lastplayed', None),
-	('id', None),
-	('set', None),
-	('status', None),
-	('code', None),
-	('studio', None),
-	('trailer', None)
-	)
+    ('title', None),
+    ('showtitle', None),
+    ('uniqueid', None),
+    ('outline', None),
+    ('plot', None),
+    ('tagline', None),
+    ('mpaa', None),
+    ('playcount', None),
+    ('lastplayed', None),
+    ('id', None),
+    ('set', None),
+    ('status', None),
+    ('code', None),
+    ('studio', None),
+    ('trailer', None)
+    )
 
 
 _int_elements = (
-	('votes', None),
-	('top250', None),
-	('season', None),
-	('episode', None),
-	('displayseason', None),
-	('displayepisode', None),
-	('runtime', None)
-	)
+    ('votes', None),
+    ('top250', None),
+    ('season', None),
+    ('episode', None),
+    ('displayseason', None),
+    ('displayepisode', None),
+    ('runtime', None)
+    )
 
 
 _float_elements = (('rating', None), ('epbookmark', None))
 
 
 def _elements():
-	elements = {
-		'aired': Date('aired'),
-		'dateadded': Date('dateadded', format_string='%Y-%m-%d %H:%M:%S'),
-		'premiered': Date('premiered'),
-		'year': Date('year', '%Y'),
-		'episodeguide': episodeguide.EpisodeGuide(),
-		'resume': playback.Resume(),
-		'actors': actors.Actors(),
-		'episodes': episodes.Episodes(),
-		'genres': genres.Genres(),
-		'thumbs': thumbs.Thumbs()
-		}
-	elements.update({k: String(k, v) for k, v in _string_elements})
-	elements.update({k: Int(k, v) for k, v in _int_elements})
-	elements.update({k: Float(k, v) for k, v in _float_elements})
-	return elements
+    elements = {
+        'aired': Date('aired'),
+        'dateadded': Date('dateadded', format_string='%Y-%m-%d %H:%M:%S'),
+        'premiered': Date('premiered'),
+        'year': Date('year', '%Y'),
+        'episodeguide': episodeguide.EpisodeGuide(),
+        'resume': playback.Resume(),
+        'actors': actors.Actors(),
+        'episodes': episodes.Episodes(),
+        'genres': genres.Genres(),
+        'thumbs': thumbs.Thumbs()
+        }
+    elements.update({k: String(k, v) for k, v in _string_elements})
+    elements.update({k: Int(k, v) for k, v in _int_elements})
+    elements.update({k: Float(k, v) for k, v in _float_elements})
+    return elements
 
 
 class TVShow(Node, _oodict.Mixin):
 
     root_node = "tvshow"
 
-	def __init__(self, **details):
-		super().__init__(self.root_node)
-		self.data = _elements()
-		self.update_data(details)
+    def __init__(self, **details):
+        super().__init__(self.root_node)
+        self.data = _elements()
+        self.update_data(details)
 
-	@property
-	def children(self):
-		for epp in self.episodes:
-			epp.genres = self.genres
-		return self.data.values()
+    @property
+    def children(self):
+        for epp in self.episodes:
+            epp.genres = self.genres
+        return self.data.values()

--- a/nfo/nodes/tvshows.py
+++ b/nfo/nodes/tvshows.py
@@ -60,8 +60,10 @@ def _elements():
 
 class TVShow(Node, _oodict.Mixin):
 
+    root_node = "tvshow"
+
 	def __init__(self, **details):
-		super().__init__('tvshow')
+		super().__init__(self.root_node)
 		self.data = _elements()
 		self.update_data(details)
 

--- a/nfo/parser.py
+++ b/nfo/parser.py
@@ -1,0 +1,45 @@
+"""Module to parse strings and file to nfo objects."""
+from lxml import etree
+
+from nfo.tvshow import TVShow
+
+
+class NfoParser(object):
+    """Lxml etree parser to any of our kodi "nfo" objects.
+
+    https://lxml.de/parsing.html
+    """
+
+    def __init__(self):
+        self.nfo_object = None
+        self.last_tags_parsed = []
+
+    def start(self, tag, attrib):
+        if not self.last_tags_parsed:
+            # Testing the value of the first tag of the source parsed,
+            # to choose the right nfo object
+            if tag == TVShow.root_node:
+                self.nfo_object = TVShow()
+            else:
+                raise Exception("root node missing, no nfo object found")
+
+        self.last_tags_parsed.append((tag, []))
+
+    def data(self, data):
+        self.last_tags_parsed[-1][1].append(data)
+
+    def comment(self, text):
+        pass
+
+    def end(self, tag):
+        tag, data = self.last_tags_parsed.pop()
+        self.nfo_object.update_data({tag: " ".join(data)})
+
+    def close(self):
+        return self.nfo_object
+
+
+def parse(source):
+    """Parse a given source and returns the right Nfo object populated."""
+    parser = etree.XMLParser(target=NfoParser())
+    return etree.parse(source, parser=parser)


### PR DESCRIPTION
Hi, 
this PR does 3 things : 
* remove default date in Date node (see kodi nfo page : this is not mandatory) 
* replace tabs with 4 spaces in tvshows.py (sorry for this one, I can rollback if you prefer) 
* creates a new parser.py module with a NfoParser class : it's a very simple parser since nfo files are not nested xml, and it leverages the work you made on the `Node.update_data` function. 

Just use `nfo.parser.parse(file)` to create a TVShow object from file (or StringIO). It is autodetected from the root tag of the file. 